### PR TITLE
Remove precompiled header and a nonexistent .cpp file

### DIFF
--- a/CutOptim/CutOptim/CutOptim.vcxproj
+++ b/CutOptim/CutOptim/CutOptim.vcxproj
@@ -155,7 +155,6 @@
     <ClInclude Include="..\..\include\Geometry.h" />
     <ClInclude Include="..\..\include\nanosvg.h" />
     <ClInclude Include="..\..\include\SvgDoc.h" />
-    <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
@@ -166,13 +165,6 @@
     <ClCompile Include="..\..\src\Optimize.cpp" />
     <ClCompile Include="..\..\src\SvgDoc.cpp" />
     <ClCompile Include="..\..\src\SvgPath.cpp" />
-    <ClCompile Include="CutOptim.cpp" />
-    <ClCompile Include="stdafx.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
-    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Doesn't include a project version update, but a standard VS upgrade to a new target should work just fine. 