### PR TITLE
Change optimizing_level to int to avoid "The output from the extension could not be parsed."

### DIFF
--- a/cutoptim.inx
+++ b/cutoptim.inx
@@ -16,7 +16,7 @@
 	</param>
 	<param name="distance" type="float" min="0.8" max="10.0" _gui-text="Min distance between objects">2.0</param>
 	<param name="max_length" type="float" min="0" max="1000" _gui-text="Max length of single segment">1000</param>
-	<param name="optimizing_level" type="float" min="1" max="10" _gui-text="Optimizing level">1</param>
+	<param name="optimizing_level" type="int" min="1" max="10" _gui-text="Optimizing level">1</param>
 	<param name="original" type="boolean" _gui-text="Keep original layer in output">false</param>
  	<param name="firstpos" type="enum" _gui-text="Select option for largest element placement: ">
 		<_item value="TL">Top Left</_item>


### PR DESCRIPTION
inkscape 1.3 creates a command like this on Windows:
CutOptim.exe --unit=mm --distance=1 --max_length=1000.0 --optimizing_level=1.0 --original=false --firstpos=TL --free_rot=true --angle=90.0 --nested=true --debug_file=true C:\Users\aaa\AppData\Local\Temp\ink_ext_XXXXXX.svgRER8B2

This is the error:
error parsing options: Argument '1.0' failed to parse

It is quite hard to figure out what is going on as this is the error in the UI:
![image](https://github.com/thierry7100/CutOptim/assets/4578040/cd21aa96-9455-4412-a851-d8864263e47b)
